### PR TITLE
Simple SEO and mini perf optimizations.

### DIFF
--- a/contents/index.json
+++ b/contents/index.json
@@ -1,4 +1,6 @@
 {
   "filename": "index.html",
-  "template": "pages/index.html.njk"
+  "template": "pages/index.html.njk",
+  "title": "CSSconf EU | Friday, June 1 2018 | Berlin, Germany",
+  "description": "CSSconf EU is conference dedicated to all those passionate about design, CSS, and the web. For the community, by the community."
 }

--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -5,13 +5,11 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
-  <title>
-    {% if page.name %}
-      {{ page.name }} -
-    {% endif %}
-    {{ name }}
-  </title>
-  <meta name="description" content="{{ site.description }}">
+  <title>{% if page.title %}{{ page.title }}{% endif %}</title>
+  {% if page.description %}
+    <meta name="description" content="{{ page.description }}">
+    <meta property="og:description" content="{{ page.description }}"/>
+  {% endif %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="{{ contents.css["main.css"].url }}">
   {#<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">#}
@@ -19,17 +17,14 @@
   <meta property="og:url" content="{{ url }}"/>
   <meta property="og:type" content="website"/>
   <meta property="og:title"
-        content="{{ title }}"/>
-  <meta property="og:description"
-        content="{{ description }}"/>
+        content="{{ page.title }}"/>
+
   <meta property="og:image"
         content="{{ contents.images['open-graph-image.png'].url }}"/>
   {% include "../partials/favicon.html.njk" %}
 </head>
 <body class="{% block bodyClass %}{% endblock %}">
-  <div style="height: 0; width: 0; position: absolute; visibility: hidden;">
-    {{ contents.svg['sprite.svg'].sprite }}
-  </div>
+
 
 {% include "../partials/header.njk" %}
 
@@ -40,6 +35,10 @@
 
 {% include "../partials/globe.html.njk" %}
 {% include "../partials/footer.html.njk" %}
+
+<div style="height: 0; width: 0; position: absolute; visibility: hidden;">
+  {{ contents.svg['sprite.svg'].sprite }}
+</div>
 
 <script>
   (function (i, s, o, g, r, a, m) {
@@ -57,5 +56,6 @@
   ga('create', 'UA-41264845-2', 'auto');
   ga('send', 'pageview');
 </script>
+
 </body>
 </html>


### PR DESCRIPTION
- Only perf change is to move the SVG sprite to the back.
- Changes the meta data to be only page based. As a rule of thumb one should never have the same meta data on every page. I did not fix this for `og:image` but I'd recommend to either have a per-page image or to not define this.`