### PR TITLE
Add missing page templates (with old content)

### DIFF
--- a/contents/accessibility.json
+++ b/contents/accessibility.json
@@ -1,0 +1,4 @@
+{
+  "template": "pages/accessibility.html.njk",
+  "title": "Accessibility"
+}

--- a/contents/childcare.json
+++ b/contents/childcare.json
@@ -1,0 +1,4 @@
+{
+  "template": "pages/childcare.html.njk",
+  "title": "Childcare"
+}

--- a/contents/copy/accessibility/main.md
+++ b/contents/copy/accessibility/main.md
@@ -1,0 +1,13 @@
+---
+title: Accessibility Statement
+introText: >
+  CSSconf EU and JSConf EU are inclusive conferences and want to be accessible.
+---
+
+We make sure that all official events related to these conferences are well accessible to people with physical disabilities, by both checking with the venue owner and by visiting them personally beforehand. However, we are aware that accessibility issues are diverse and this does not cover everything.
+
+If you are interested in our conferences, but have any kind of accessibility problem that needs to be resolved before you can attend, please [get in contact](mailto:contact@cssconf.eu). We will reserve you a ticket until we found out whether your issue can be resolved. This includes setting up special assistance offers.
+
+If you are in need of an assistant, they will not be required to buy a ticket.
+
+We would love to welcome you to our conferences!

--- a/contents/copy/childcare/main.md
+++ b/contents/copy/childcare/main.md
@@ -1,0 +1,19 @@
+---
+title: Childcare
+introText: >
+  👦🏾👶👧🏼
+---
+
+## We’re happy to be able to offer free childcare at the venue for children aged 3 and above.
+
+Between 9am and 7pm, there will be a dedicated area with childcare professionals who will look after your children while you enjoy the conference.
+
+In order to use our child care services, we ask that you register a separate, free ticket below and let us know everything that is important to keep your child happy during the conference. Please note that places are limited and available on a first-come-first-serve basis.
+
+For CSSconf EU, please register here. XXX ADD LINK
+
+For JSConf EU, please register here. XXX ADD LINK
+
+For parents with younger infants, we will offer a separate room to retreat to, equipped with comfy seats, diapers and other basic necessities.
+
+We look forward to welcoming you and your children to the conference!

--- a/contents/copy/diversity/main.md
+++ b/contents/copy/diversity/main.md
@@ -1,0 +1,39 @@
+---
+title: Diversity Support Tickets
+introText: >
+  Enabling more people to attend CSSconf EU
+---
+
+## CSSconf EU strives to create a genuinely welcoming, safe, and inspiring event for the CSS community. This year we’re offering Diversity Support Tickets to allow an even more diverse audience to participate in the conference.
+
+## How do Diversity Support Tickets work?
+
+You purchase a ticket for yourself, and enable another person of the conference’s choosing to attend the event by paying a share towards their ticket. The support options range from contributing 25%, 50% and up to 100% towards a full ticket. We thank you in advance for your generosity and awesomeness and look forward to a more inclusive CSSconf EU than ever before.
+
+We are very grateful and would like to say a big Thank You to the companies and individuals who donated to our [Scholarship Program](/scholarships): ❤️
+
+Small Improvements Software, Benny Neugebauer, Accenture, The Home Depot QuoteCenter, Bitcrowd GmbH, Igalia, itemis AG, Stephen Greig, Dave Prosser, Kelly Jordan, Christopher Astfalk, always twisted, Elias Liedholm, AgenturWebfox GmbH, Mandy Patel, exutec, Lavinia Rizac, GitHub, and 17 anonymous supporters.
+
+## Why Diversity Support Tickets?
+
+We believe that only a diverse community is a healthy community, and we welcome and encourage participation by everyone. The Diversity Support Tickets initiative is one attempt to increase the number of participants that would love to attend but are financially or otherwise unable to do so.
+
+## Who will receive the sponsored tickets? Can I apply?
+
+Anyone from an under-represented group in tech is invited to [apply for a scholarship](/scholarships). This includes, but is not limited to: women, people of colour, LGBTQIA+ people, disabled people, and people facing economic or social hardships. We do outreach with organizations that represent disadvantaged groups in tech to reach the right audience. In the case where there are more qualified applicants than there are ticket, we have a lottery for the available spots, with priority given based on a combination of need and impact. The number of spots is determined by Diversity Support Ticket sales and dedicated diversity contributions made by our sponsors.
+
+The deadline for scholarship applications for CSSconf EU 2017 has now passed! XXX UPDATE
+
+## What else are you doing to increase diversity?
+
+In addition to the Diversity Support Tickets initiative for attendees, we also aspire to encourage a diverse group of speakers to apply. We provide a lot of information about the application process, additional blog posts covering the topic, as well as personal support (emails, slack chat). We reach out via email to under-represented individuals and groups to encourage them to submit talk proposals.
+
+CSSconf EU and its [team](/team) are active members of the local community. In our desire to support those just getting started in web development we organize free weekend workshops called [CSSclasses](http://cssclasses.cssconf.eu/). Those workshops aim to introduce people completely new to programming to the basics of becoming creative with code. Each event has up to 70 attendees, and is completely free of charge. We have run over 15 CSSclasses events in Berlin, Hamburg and Edinburgh.
+
+We operate under a [Code of Conduct](/code-of-conduct) that we enforce. We educate ourselves and our team about how to put on a safe and inclusive event. We are constantly learning, educating ourselves on how to do better, and we plan so as to be as transparent about our process as possible, and the Diversity Support Tickets initiative we launched in 2015 is one attempt at improving in this area.
+
+## Can I contribute or sponsor in other ways?
+
+Help from sponsors is greatly needed – if you are interested in supporting CSSconf EU to become more accessible and inclusive, you can read more [here](/sponsors), or reach out directly via [e-mail](mailto:contact@cssconf.eu).
+
+Go to schedule 🎉 XXX ADD BUTTON

--- a/contents/copy/info/main.md
+++ b/contents/copy/info/main.md
@@ -1,0 +1,117 @@
+---
+title: Information
+introText: >
+  Dedicated to everyone who loves and writes CSS: On May 5 2017, CSSconf EU will gather the international CSS community in Berlin, Germany. This is your chance to meet top-notch engineers & web designers, world-class speakers, and CSS-loving people at this one-day, one-track conference.
+---
+
+## Mission & Values
+
+CSSconf EU is a not-for-profit community conference run by a team of volunteers. We are all active members of the tech community, and run or contribute to various free local meetups, workshops, and education initiatives. With CSSconf EU, we aim to bring the international CSS crowd together with our beloved local Berlin community. We are humbled to look back to three sold-out events where we welcomed the world’s most excellent CSS speakers on our stage, and we are proud to have always put an inclusive and welcoming culture first. We operate under a Code of Conduct, run a scholarship program, write articles to be transparent, and are committed to diversity and accessibility.
+
+Watch last year’s film
+
+XXX EMBED MOVIE
+
+## Date & Venue
+
+CSSconf EU will 2017 take place on May 5, 2017 in Berlin’s Arena Halle, offering a day packed with inspiring and insightful talks and time well spent in the company of great people. This year we’re planning the most adventurous and ambitious CSSconf EU ever – be prepared for CSSconf EU, the Festival Edition, featuring a newer, bigger, more exciting venue that we’ll pack with some surprises.
+
+### Speakers, Topics, Language
+
+CSSconf EU unites top international speakers and newcomers with fresh ideas. They will discuss cutting-edge technologies and questions around front-end development and web design – with a specific focus on CSS.
+
+See full line-up and Schedule
+
+Talks are always in English, and video recordings will be released for free after the event. All speakers were selected via an open Call for Speakers. The voting on all proposals took place in January 2017.
+
+### Catering
+
+Our chefs and coffee specialists will make sure you don’t go hungry or run the risk of low caffeination throughout the day. You can expect quality coffee, a full breakfast, healthy lunch with various options, and hearty dinner. All meals include vegetarian, vegan, gluten-free options.
+
+### Tickets
+
+Until sold out, you can buy tickets here.
+
+Arena Berlin
+Eichenstraße 4, Berlin
+12435 Germany
+
+## Festival Area
+
+This year, for the first time ever, we have a Festival Area! We dedicated a part of our large and beautiful venue just to fun activities and short live demos that you can check out during breaks. You’ll be able to: meet the companies that support CSSconf EU, chat with the people behind open source projects / community initiatives, be wooed by { live : JS }, see the CSSconf bags getting printed, take selfies in our photo booth, play foosball, charge up your phones, grab a frozen yogurt and … sit on beanbags!
+
+Supporting Companies: CSSconf EU wouldn’t be possible without the support of great companies: our sponsors! Many of them will be available for chats and demos in our Festival Area. Make sure to stop by at the booths of SinnerSchrader, eBay Tech, Mozilla, Google, Twilio, AMP, Cloudflare, Shopify and Host1Plus.
+
+Community Area: The CSS Community is awesome, and we’re proud to have some fantastic contributors and organizers as our guests. Come and meet them, get a demo, and learn how you can get involved too: Lauren Dorman for Tachyons, Yoshua Wuyts for Choo and Dat, Aga Naplocha for The Awwwesomes, Glen Maddern for styled-components, Katrin Kampfrath for CSSstudies, Bastian Albers for CSSclasses, Jan Borchardt for opensourcedesign, Katharina Jockenhöfer for upfront.ug.
+
+Fun Stuff: We got you covered. During breaks, you can meet the crew behind { live : JS } and explore their audio/visual arts, learn from SDW printshop how the CSSconf bag is printed, take selfies with friends in our photo booth, play foosball, or relax in a beanbag and flip through the latest edition of Offscreen Magazine.
+
+## Social Events
+
+Thursday Warm Up: As it has become our tradition in the past years, we will have a small warmup event on the evening before the conference. Around 7pm on Thursday, we will gather to get some drinks at Volksbar Berlin (Rosa-Luxemburg-Straße 39, 10178 Berlin).
+
+CSSconf EU Dinner: Around 7pm on Friday, after the talks have ended and the big family photo has been taken, we’ll come together for food, drinks and, most importantly, to talk and discuss the events of the day with fellow CSSconf EU attendees. We’ll serve a streetfood-style dinner and snacks, including tasty vegan and vegetarian options, to keep you sated.
+
+CSSconf Closing Party: What would a great day be if it didn’t end in celebration! The party will take place at Glashaus, a river-facing building adjacent to the conference venue, so there’ll be no long walks from dinner to drinks to party. Expect free drinks (except hard alcohol) and music from our DJ @berlindisaster!
+Friends, family and the community are also welcome to join us, provided they present a party ticket at the door.
+
+All parties and gatherings at a glance
+
+Thursday, May 4: CSSconf EU Warm-Up, 7pm, Volksbar
+Friday, May 5: CSSconf EU Closing / JSConf EU Opening Party, 8pm, Glashaus
+Saturday, May 6: JSConf EU Main Party, 9pm, Glashaus
+Sunday, May 7: JSConf EU Closing Party, 7:30pm, Hoppetosse
+Monday, May 8: relax.js Brunch, 10am, Datscha Xberg
+For attendees of CSSconf EU and JSConf EU, access to the above is included in the conference ticket. Please make sure to wear your badge in order to enter the evening events.
+
+If you’re not attending the conferences, but would like to come along to the above gatherings, you can purchase limited Party Tickets. 
+Buy CSSconf EU Party Ticket (Friday)
+Buy JSConf EU Party Ticket (Saturday)
+
+wwwtf.berlin
+
+CSSconf EU will run alongside JSConf EU and as part of wwwtf.berlin, a festival of community events in Berlin. There will be many social events happening before and on the weekend of CSSconf EU. Check out the full overview on wwwtf.berlin.
+
+## Accessibility and Childcare
+
+We do our best to ensure that the conference, venue and events throughout the day are fully accessible, so that all attendees can wholly participate in and enjoy the conference. To do this, we work closely with venue and volunteer staff prior to and on the day of the event to ensure disability access to all areas.
+
+As part of our commitment to accessibility, we’re bringing real-time transcription (CART) to CSSconf EU. There will be a live feed of every word of each talk.
+
+We’re happy to be able to offer free, all-day childcare at the venue for children aged 3 and above. For parents with younger infants, we will provide a quiet room equipped with comfy seats, diapers and other essentials where you can retreat to throughout the day. 
+Read more and register a free childcare ticket
+
+## Travel & Transport
+
+### Berlin’s Airports
+
+Berlin has two airports, both of which are located close to the city center, a 30-minute taxi ride from the venue (ca. EUR 30). There are also trains and buses that connect the airports to Berlin’s city center.
+
+Berlin-Tegel (TXL)
+Berlin-Schönefeld (SXF)
+
+### Public Transport
+
+Berlin has many public transport options. The subway, trains, buses, trams are all operated by BVG. We recommend getting one of the tourist tickets for the length of your stay – this will allow you to use all subway trains, trams and buses in all of Berlin, plus it comes with discounts for popular sights, museums, and other attractions.
+
+### Bike
+
+Berlin’s flat geography, its many bike lanes and the friendly weather in early May make it perfect to get around by bike! Check with your hotel or hostel if they have bikes to rent out, or find your perfect bike at one of the many bike rental places.
+
+###  Taxi
+
+Taxis in Berlin are affordable and everywhere. You can usually hail one on the street, or use apps like MyTaxi to order one.
+
+## Accommodation
+
+Below are a two hotels we recommend, both a short walk away from our venue. If neither of those fit your needs, check out HRS or private accommodation options like AirBnB or Couchsurfing.
+
+Hotel NHow (20 min walk)
+Michelberger Hotel (20 min walk)
+If you’d like to team up with other attendees to travel to or stay in Berlin, let us and the community know on Twitter: #cssconfeu – we will help spread the word!
+
+## Stay Tuned
+
+We post all updates around CSSconf EU on Twitter. Use the hashtag #cssconfeu to tweet about the conference, connect with other attendees, and share your photos of the day when the time comes! You can also find us on Facebok and Lanyrd and see who else is attending.
+
+Any questions we didn’t address? Reach out to us, the team is here to help!

--- a/contents/copy/team/main.md
+++ b/contents/copy/team/main.md
@@ -1,0 +1,27 @@
+---
+title: Team
+introText: >
+  Meet the people behind CSSconf EU
+---
+
+This event is made possible by the great work of the many volunteers who spend a lot of their time pouring their blood and sweat into preparing a fantastic day for you.
+
+## The Organizers
+
+Kristina Schneider, [@kriesse](https://twitter.com/kriesse)
+Polly Hristova, [@rtrospekt](https://twitter.com/rtrospekt)
+
+## Our big thanks and love go to:
+
+Felicitas Kugland, [@kotzendekrabbe](https://twitter.com/kotzendekrabbe)
+Kevin Lorenz, [@verpixelt](https://twitter.com/verpixelt)
+Lourdes Montano, [@louMontano](https://twitter.com/louMontano)
+Lucie Höhler, [@autofocus](https://twitter.com/autofocus)
+Lukasz Klis, [@lukaszklis](https://twitter.com/lukaszklis)
+Martin Schuhfuss, [@usefulthink](https://twitter.com/usefulthink)
+Michael P. Pfeiffer, [@m_p_pfeiffer](https://twitter.com/m_p_pfeiffer)
+Nicolas Zimmel, [@toomanyclouds](https://twitter.com/toomanyclouds)
+Ola Gasidlo, [@misprintedtype](https://twitter.com/misprintedtype)
+Sean Fridman, [@sfrdmn](https://twitter.com/sfrdmn)
+Simone Haas, [@haas_simone](https://twitter.com/haas_simone)
+Silke Voigts, [@silkine](https://twitter.com/silkine)

--- a/contents/diversity-support-tickets.json
+++ b/contents/diversity-support-tickets.json
@@ -1,0 +1,4 @@
+{
+  "template": "pages/diversity-support-tickets.html.njk",
+  "title": "Diversity Support Tickets"
+}

--- a/contents/info.json
+++ b/contents/info.json
@@ -1,0 +1,4 @@
+{
+  "template": "pages/info.html.njk",
+  "title": "Information"
+}

--- a/contents/team.json
+++ b/contents/team.json
@@ -1,0 +1,4 @@
+{
+  "template": "pages/team.html.njk",
+  "title": "Team"
+}

--- a/templates/pages/accessibility.html.njk
+++ b/templates/pages/accessibility.html.njk
@@ -1,0 +1,20 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% block content %}
+  <section class="c-intro">
+    <div class="l-container">
+      <h1 class="c-intro__title">{{ contents.copy.accessibility['main.md'].metadata.title }}</h1>
+      <p class="c-intro__text copy--max">
+        {{ contents.copy.accessibility['main.md'].metadata.introText }}
+      </p>
+    </div>
+  </section>
+
+  <div class="l-container">
+    <main>
+      <div class="markdown--indented-paragraphs">
+        {{ contents.copy.accessibility['main.md'].html }}
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/templates/pages/childcare.html.njk
+++ b/templates/pages/childcare.html.njk
@@ -1,0 +1,20 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% block content %}
+  <section class="c-intro">
+    <div class="l-container">
+      <h1 class="c-intro__title">{{ contents.copy.childcare['main.md'].metadata.title }}</h1>
+      <p class="c-intro__text copy--max">
+        {{ contents.copy.childcare['main.md'].metadata.introText }}
+      </p>
+    </div>
+  </section>
+
+  <div class="l-container">
+    <main>
+      <div class="markdown--indented-paragraphs">
+        {{ contents.copy.childcare['main.md'].html }}
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/templates/pages/diversity-support-tickets.html.njk
+++ b/templates/pages/diversity-support-tickets.html.njk
@@ -1,0 +1,20 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% block content %}
+  <section class="c-intro">
+    <div class="l-container">
+      <h1 class="c-intro__title">{{ contents.copy.diversity['main.md'].metadata.title }}</h1>
+      <p class="c-intro__text copy--max">
+        {{ contents.copy.diversity['main.md'].metadata.introText }}
+      </p>
+    </div>
+  </section>
+
+  <div class="l-container">
+    <main>
+      <div class="markdown--indented-paragraphs">
+        {{ contents.copy.diversity['main.md'].html }}
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/templates/pages/info.html.njk
+++ b/templates/pages/info.html.njk
@@ -1,0 +1,20 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% block content %}
+  <section class="c-intro">
+    <div class="l-container">
+      <h1 class="c-intro__title">{{ contents.copy.info['main.md'].metadata.title }}</h1>
+      <p class="c-intro__text copy--max">
+        {{ contents.copy.info['main.md'].metadata.introText }}
+      </p>
+    </div>
+  </section>
+
+  <div class="l-container">
+    <main>
+      <div class="markdown--indented-paragraphs">
+        {{ contents.copy.info['main.md'].html }}
+      </div>
+    </main>
+  </div>
+{% endblock %}

--- a/templates/pages/team.html.njk
+++ b/templates/pages/team.html.njk
@@ -1,0 +1,20 @@
+{% extends "../layouts/default.html.njk" %}
+
+{% block content %}
+  <section class="c-intro">
+    <div class="l-container">
+      <h1 class="c-intro__title">{{ contents.copy.team['main.md'].metadata.title }}</h1>
+      <p class="c-intro__text copy--max">
+        {{ contents.copy.team['main.md'].metadata.introText }}
+      </p>
+    </div>
+  </section>
+
+  <div class="l-container">
+    <main>
+      <div class="markdown--indented-paragraphs">
+        {{ contents.copy.team['main.md'].html }}
+      </div>
+    </main>
+  </div>
+{% endblock %}


### PR DESCRIPTION
closes https://github.com/cssconf/2018.cssconf.eu/issues/25 

I've added all the pages from 2017 I could find that are still missing - but I get a 404 if I try to see them locally. Am I missing something? @usefulthink @lukaszklis 