### PR TITLE
update info copy to 2018

### DIFF
--- a/contents/copy/info/main.md
+++ b/contents/copy/info/main.md
@@ -1,20 +1,20 @@
 ---
 title: Information
 introText: >
-  Dedicated to everyone who loves and writes CSS: On May 5 2017, CSSconf EU will gather the international CSS community in Berlin, Germany. This is your chance to meet top-notch engineers & web designers, world-class speakers, and CSS-loving people at this one-day, one-track conference.
+  Dedicated to everyone who loves and writes CSS: On June 1st 2018, CSSconf EU will gather the international CSS community in Berlin, Germany. This is your chance to meet top-notch engineers & web designers, world-class speakers, and CSS-loving people at this one-day, one-track conference.
 ---
 
 ## Mission & Values
 
 CSSconf EU is a not-for-profit community conference run by a team of volunteers. We are all active members of the tech community, and run or contribute to various free local meetups, workshops, and education initiatives. With CSSconf EU, we aim to bring the international CSS crowd together with our beloved local Berlin community. We are humbled to look back to three sold-out events where we welcomed the world’s most excellent CSS speakers on our stage, and we are proud to have always put an inclusive and welcoming culture first. We operate under a Code of Conduct, run a scholarship program, write articles to be transparent, and are committed to diversity and accessibility.
 
-Watch last year’s film
+### Watch last year’s film
 
-XXX EMBED MOVIE
+<iframe width="560" height="315" src="https://www.youtube.com/embed/8hM7WBY7dDw" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
 
 ## Date & Venue
 
-CSSconf EU will 2017 take place on May 5, 2017 in Berlin’s Arena Halle, offering a day packed with inspiring and insightful talks and time well spent in the company of great people. This year we’re planning the most adventurous and ambitious CSSconf EU ever – be prepared for CSSconf EU, the Festival Edition, featuring a newer, bigger, more exciting venue that we’ll pack with some surprises.
+CSSconf EU will take place on June 1st, 2018 in Berlin’s Arena Halle, offering a day packed with inspiring and insightful talks and time well spent in the company of great people. This year we’re planning the most adventurous and ambitious CSSconf EU ever – be prepared for CSSconf EU, the Festival Edition, featuring a newer, bigger, more exciting venue that we’ll pack with some surprises.
 
 ### Speakers, Topics, Language
 
@@ -22,7 +22,7 @@ CSSconf EU unites top international speakers and newcomers with fresh ideas. The
 
 See full line-up and Schedule
 
-Talks are always in English, and video recordings will be released for free after the event. All speakers were selected via an open Call for Speakers. The voting on all proposals took place in January 2017.
+Talks are always in English, and video recordings will be released for free after the event. All speakers re selected via an open Call for Speakers. The voting on all proposals takes place in January 2018.
 
 ### Catering
 
@@ -30,7 +30,7 @@ Our chefs and coffee specialists will make sure you don’t go hungry or run the
 
 ### Tickets
 
-Until sold out, you can buy tickets here.
+Until sold out, you can <a href="https://ti.to/cssconfeu/cssconfeu-2018/" target="_blank">buy tickets here</a>.
 
 Arena Berlin
 Eichenstraße 4, Berlin
@@ -40,22 +40,26 @@ Eichenstraße 4, Berlin
 
 This year, for the first time ever, we have a Festival Area! We dedicated a part of our large and beautiful venue just to fun activities and short live demos that you can check out during breaks. You’ll be able to: meet the companies that support CSSconf EU, chat with the people behind open source projects / community initiatives, be wooed by { live : JS }, see the CSSconf bags getting printed, take selfies in our photo booth, play foosball, charge up your phones, grab a frozen yogurt and … sit on beanbags!
 
-Supporting Companies: CSSconf EU wouldn’t be possible without the support of great companies: our sponsors! Many of them will be available for chats and demos in our Festival Area. Make sure to stop by at the booths of SinnerSchrader, eBay Tech, Mozilla, Google, Twilio, AMP, Cloudflare, Shopify and Host1Plus.
+Supporting Companies: CSSconf EU wouldn’t be possible without the support of great companies: our sponsors! Many of them will be available for chats and demos in our Festival Area. Make sure to stop by at the booths of our supporters.
 
-Community Area: The CSS Community is awesome, and we’re proud to have some fantastic contributors and organizers as our guests. Come and meet them, get a demo, and learn how you can get involved too: Lauren Dorman for Tachyons, Yoshua Wuyts for Choo and Dat, Aga Naplocha for The Awwwesomes, Glen Maddern for styled-components, Katrin Kampfrath for CSSstudies, Bastian Albers for CSSclasses, Jan Borchardt for opensourcedesign, Katharina Jockenhöfer for upfront.ug.
+Community Area: The CSS Community is awesome, and we’re proud to have some fantastic contributors and organizers as our guests. Come and meet them, get a demo, and learn how you can get involved too.
 
-Fun Stuff: We got you covered. During breaks, you can meet the crew behind { live : JS } and explore their audio/visual arts, learn from SDW printshop how the CSSconf bag is printed, take selfies with friends in our photo booth, play foosball, or relax in a beanbag and flip through the latest edition of Offscreen Magazine.
+<!-- Fun Stuff: We got you covered. During breaks, you can meet the crew behind { live : JS } and explore their audio/visual arts, learn from SDW printshop how the CSSconf bag is printed, take selfies with friends in our photo booth, play foosball, or relax in a beanbag and flip through the latest edition of Offscreen Magazine. -->
 
 ## Social Events
 
-Thursday Warm Up: As it has become our tradition in the past years, we will have a small warmup event on the evening before the conference. Around 7pm on Thursday, we will gather to get some drinks at Volksbar Berlin (Rosa-Luxemburg-Straße 39, 10178 Berlin).
+Thursday Warm Up: As it has become our tradition in the past years, we will have a small warmup event on the evening before the conference.
+<!-- Around 7pm on Thursday, we will gather to get some drinks at Volksbar Berlin (Rosa-Luxemburg-Straße 39, 10178 Berlin). -->
 
-CSSconf EU Dinner: Around 7pm on Friday, after the talks have ended and the big family photo has been taken, we’ll come together for food, drinks and, most importantly, to talk and discuss the events of the day with fellow CSSconf EU attendees. We’ll serve a streetfood-style dinner and snacks, including tasty vegan and vegetarian options, to keep you sated.
+CSSconf EU Dinner: Around 7pm on Friday, after the talks have ended and the big family photo has been taken, we’ll come together for food, drinks and, most importantly, to talk and discuss the events of the day with fellow CSSconf EU attendees.
+<!-- We’ll serve a streetfood-style dinner and snacks, including tasty vegan and vegetarian options, to keep you sated. -->
 
-CSSconf Closing Party: What would a great day be if it didn’t end in celebration! The party will take place at Glashaus, a river-facing building adjacent to the conference venue, so there’ll be no long walks from dinner to drinks to party. Expect free drinks (except hard alcohol) and music from our DJ @berlindisaster!
-Friends, family and the community are also welcome to join us, provided they present a party ticket at the door.
+CSSconf Closing Event: What would a great day be if it didn’t end in celebration! More infos about our evening program soon.
 
-All parties and gatherings at a glance
+<!-- The party will take place at Glashaus, a river-facing building adjacent to the conference venue, so there’ll be no long walks from dinner to drinks to party. Expect free drinks (except hard alcohol) and music from our DJ @berlindisaster!
+Friends, family and the community are also welcome to join us, provided they present a party ticket at the door. -->
+
+<!-- All parties and gatherings at a glance
 
 Thursday, May 4: CSSconf EU Warm-Up, 7pm, Volksbar
 Friday, May 5: CSSconf EU Closing / JSConf EU Opening Party, 8pm, Glashaus
@@ -64,9 +68,9 @@ Sunday, May 7: JSConf EU Closing Party, 7:30pm, Hoppetosse
 Monday, May 8: relax.js Brunch, 10am, Datscha Xberg
 For attendees of CSSconf EU and JSConf EU, access to the above is included in the conference ticket. Please make sure to wear your badge in order to enter the evening events.
 
-If you’re not attending the conferences, but would like to come along to the above gatherings, you can purchase limited Party Tickets. 
+If you’re not attending the conferences, but would like to come along to the above gatherings, you can purchase limited Party Tickets.
 Buy CSSconf EU Party Ticket (Friday)
-Buy JSConf EU Party Ticket (Saturday)
+Buy JSConf EU Party Ticket (Saturday) -->
 
 wwwtf.berlin
 
@@ -78,7 +82,7 @@ We do our best to ensure that the conference, venue and events throughout the da
 
 As part of our commitment to accessibility, we’re bringing real-time transcription (CART) to CSSconf EU. There will be a live feed of every word of each talk.
 
-We’re happy to be able to offer free, all-day childcare at the venue for children aged 3 and above. For parents with younger infants, we will provide a quiet room equipped with comfy seats, diapers and other essentials where you can retreat to throughout the day. 
+We’re happy to be able to offer free, all-day childcare at the venue for children aged 3 and above. For parents with younger infants, we will provide a quiet room equipped with comfy seats, diapers and other essentials where you can retreat to throughout the day.
 Read more and register a free childcare ticket
 
 ## Travel & Transport
@@ -98,7 +102,7 @@ Berlin has many public transport options. The subway, trains, buses, trams are a
 
 Berlin’s flat geography, its many bike lanes and the friendly weather in early May make it perfect to get around by bike! Check with your hotel or hostel if they have bikes to rent out, or find your perfect bike at one of the many bike rental places.
 
-###  Taxi
+### Taxi
 
 Taxis in Berlin are affordable and everywhere. You can usually hail one on the street, or use apps like MyTaxi to order one.
 
@@ -106,12 +110,13 @@ Taxis in Berlin are affordable and everywhere. You can usually hail one on the s
 
 Below are a two hotels we recommend, both a short walk away from our venue. If neither of those fit your needs, check out HRS or private accommodation options like AirBnB or Couchsurfing.
 
-Hotel NHow (20 min walk)
-Michelberger Hotel (20 min walk)
+* Hotel NHow (20 min walk)
+* Michelberger Hotel (20 min walk)
+
 If you’d like to team up with other attendees to travel to or stay in Berlin, let us and the community know on Twitter: #cssconfeu – we will help spread the word!
 
 ## Stay Tuned
 
-We post all updates around CSSconf EU on Twitter. Use the hashtag #cssconfeu to tweet about the conference, connect with other attendees, and share your photos of the day when the time comes! You can also find us on Facebok and Lanyrd and see who else is attending.
+We post all updates around [CSSconf EU on Twitter](https://twitter.com/cssconfeu). Use the hashtag #cssconfeu to tweet about the conference, connect with other attendees, and share your photos of the day when the time comes! You can also find us on [Facebook](https://www.facebook.com/cssconfeu/) and [subscribe to our newsletter](https://confirmsubscription.com/h/d/879A481DB04CB70D).
 
-Any questions we didn’t address? Reach out to us, the team is here to help!
+Any questions we didn’t address? Reach out to us at <a href="mailto:contact@cssconf.eu">contact@cssconf.eu</a>, the team is here to help!

--- a/contents/copy/info/main.md
+++ b/contents/copy/info/main.md
@@ -22,7 +22,7 @@ CSSconf EU unites top international speakers and newcomers with fresh ideas. The
 
 See full line-up and Schedule
 
-Talks are always in English, and video recordings will be released for free after the event. All speakers re selected via an open Call for Speakers. The voting on all proposals takes place in January 2018.
+Talks are always in English, and video recordings will be released for free after the event. All speakers are selected via an open Call for Speakers. The voting on all proposals takes place in January 2018.
 
 ### Catering
 


### PR DESCRIPTION
still more work to do (add links…), but it should be safe to share now. removed all misleading / outdated 2017 info.