### PR TITLE
✍️ Update info page copy and links

### DIFF
--- a/contents/copy/info/main.md
+++ b/contents/copy/info/main.md
@@ -6,7 +6,7 @@ introText: >
 
 ## Mission & Values
 
-CSSconf EU is a not-for-profit community conference run by a team of volunteers. We are all active members of the tech community, and run or contribute to various free local meetups, workshops, and education initiatives. With CSSconf EU, we aim to bring the international CSS crowd together with our beloved local Berlin community. We are humbled to look back to three sold-out events where we welcomed the world’s most excellent CSS speakers on our stage, and we are proud to have always put an inclusive and welcoming culture first. We operate under a Code of Conduct, run a scholarship program, write articles to be transparent, and are committed to diversity and accessibility.
+CSSconf EU is a not-for-profit community conference run by a team of [volunteers](/team). We are all active members of the tech community, and run or contribute to various free local meetups, workshops, and education initiatives. With CSSconf EU, we aim to bring the international CSS crowd together with our beloved local Berlin community. We are humbled to look back to three sold-out events where we welcomed the world’s most excellent CSS speakers on our stage, and we are proud to have always put an inclusive and welcoming culture first. We operate under a [Code of Conduct](/code-of-conduct), run a [scholarship program](/scholarships), write [articles to be transparent](http://blog.cssconf.eu/), and are committed to [diversity](/diversity-support-tickets) and [accessibility](/accessibility).
 
 ### Watch last year’s film
 
@@ -14,15 +14,17 @@ CSSconf EU is a not-for-profit community conference run by a team of volunteers.
 
 ## Date & Venue
 
-CSSconf EU will take place on June 1st, 2018 in Berlin’s Arena Halle, offering a day packed with inspiring and insightful talks and time well spent in the company of great people. This year we’re planning the most adventurous and ambitious CSSconf EU ever – be prepared for CSSconf EU, the Festival Edition, featuring a newer, bigger, more exciting venue that we’ll pack with some surprises.
+CSSconf EU will take place on June 1st, 2018 in [Berlin’s Arena Halle](https://www.google.de/maps/place/Arena+Berlin/@52.4966473,13.4530078,15z/data=!4m2!3m1!1s0x0:0x6852fd9350063186?sa=X&ved=0ahUKEwjP5-7ntezYAhWBDOwKHekCBFcQ_BIIigEwCg), offering a day packed with inspiring and insightful talks and time well spent in the company of great people. Building on our 2017 experiences and improvement we’re planning on using the big venue even more and present you a wonderful CSSconf EU Festival full of surprises.
+
+**Arena Berlin<br>
+Eichenstraße 4, Berlin<br>
+12435 Germany**
 
 ### Speakers, Topics, Language
 
 CSSconf EU unites top international speakers and newcomers with fresh ideas. They will discuss cutting-edge technologies and questions around front-end development and web design – with a specific focus on CSS.
 
-See full line-up and Schedule
-
-Talks are always in English, and video recordings will be released for free after the event. All speakers are selected via an open Call for Speakers. The voting on all proposals takes place in January 2018.
+Talks are always in English, and video recordings will be released for free after the event. All speakers are [selected](http://blog.cssconf.eu/2015/08/15/a-talk-selection-process-explained/) via an open Call for Speakers. The first speakers will be announced in early February 2018.
 
 ### Catering
 
@@ -32,29 +34,27 @@ Our chefs and coffee specialists will make sure you don’t go hungry or run the
 
 Until sold out, you can <a href="https://ti.to/cssconfeu/cssconfeu-2018/" target="_blank">buy tickets here</a>.
 
-Arena Berlin
-Eichenstraße 4, Berlin
-12435 Germany
-
 ## Festival Area
 
-This year, for the first time ever, we have a Festival Area! We dedicated a part of our large and beautiful venue just to fun activities and short live demos that you can check out during breaks. You’ll be able to: meet the companies that support CSSconf EU, chat with the people behind open source projects / community initiatives, be wooed by { live : JS }, see the CSSconf bags getting printed, take selfies in our photo booth, play foosball, charge up your phones, grab a frozen yogurt and … sit on beanbags!
+Introduced in 2017, we again will have a Festival Area! Part of the large and beautiful venue will be dedicated just to fun activities and short live demos that you can check out during breaks.
 
-Supporting Companies: CSSconf EU wouldn’t be possible without the support of great companies: our sponsors! Many of them will be available for chats and demos in our Festival Area. Make sure to stop by at the booths of our supporters.
+<!-- You’ll be able to: meet the companies that support CSSconf EU, chat with the people behind open source projects / community initiatives, be wooed by { live : JS }, see the CSSconf bags getting printed, take selfies in our photo booth, play foosball, charge up your phones, grab a frozen yogurt and … sit on beanbags! -->
 
-Community Area: The CSS Community is awesome, and we’re proud to have some fantastic contributors and organizers as our guests. Come and meet them, get a demo, and learn how you can get involved too.
+**Supporting Companies**: CSSconf EU wouldn’t be possible without the support of great companies: our sponsors! Many of them will be available for chats and demos in our Festival Area. Make sure to stop by at the booths of our supporters.
+
+**Community Area**: The CSS Community is awesome, and we’re proud to have some fantastic contributors and organizers as our guests. Come and meet them, get a demo, and learn how you can get involved too.
 
 <!-- Fun Stuff: We got you covered. During breaks, you can meet the crew behind { live : JS } and explore their audio/visual arts, learn from SDW printshop how the CSSconf bag is printed, take selfies with friends in our photo booth, play foosball, or relax in a beanbag and flip through the latest edition of Offscreen Magazine. -->
 
 ## Social Events
 
-Thursday Warm Up: As it has become our tradition in the past years, we will have a small warmup event on the evening before the conference.
+**Thursday Warm Up:** As it has become our tradition in the past years, we will have a small warmup event on the evening before the conference.
 <!-- Around 7pm on Thursday, we will gather to get some drinks at Volksbar Berlin (Rosa-Luxemburg-Straße 39, 10178 Berlin). -->
 
-CSSconf EU Dinner: Around 7pm on Friday, after the talks have ended and the big family photo has been taken, we’ll come together for food, drinks and, most importantly, to talk and discuss the events of the day with fellow CSSconf EU attendees.
+**CSSconf EU Dinner:** Around 7pm on Friday, after the talks have ended and the big family photo has been taken, we’ll come together for food, drinks and, most importantly, to talk and discuss the events of the day with fellow CSSconf EU attendees.
 <!-- We’ll serve a streetfood-style dinner and snacks, including tasty vegan and vegetarian options, to keep you sated. -->
 
-CSSconf Closing Event: What would a great day be if it didn’t end in celebration! More infos about our evening program soon.
+**CSSconf Closing Event:** What would a great day be if it didn’t end in celebration! More infos about our evening program soon.
 
 <!-- The party will take place at Glashaus, a river-facing building adjacent to the conference venue, so there’ll be no long walks from dinner to drinks to party. Expect free drinks (except hard alcohol) and music from our DJ @berlindisaster!
 Friends, family and the community are also welcome to join us, provided they present a party ticket at the door. -->
@@ -72,18 +72,18 @@ If you’re not attending the conferences, but would like to come along to the a
 Buy CSSconf EU Party Ticket (Friday)
 Buy JSConf EU Party Ticket (Saturday) -->
 
-wwwtf.berlin
+### wwwtf.berlin
 
-CSSconf EU will run alongside JSConf EU and as part of wwwtf.berlin, a festival of community events in Berlin. There will be many social events happening before and on the weekend of CSSconf EU. Check out the full overview on wwwtf.berlin.
+CSSconf EU will run alongside JSConf EU and as part of [wwwtf.berlin](http://wwwtf.berlin/), a festival of community events in Berlin. There will be many social events happening before and on the weekend of CSSconf EU. Check out the full overview on wwwtf.berlin.
 
 ## Accessibility and Childcare
 
 We do our best to ensure that the conference, venue and events throughout the day are fully accessible, so that all attendees can wholly participate in and enjoy the conference. To do this, we work closely with venue and volunteer staff prior to and on the day of the event to ensure disability access to all areas.
 
-As part of our commitment to accessibility, we’re bringing real-time transcription (CART) to CSSconf EU. There will be a live feed of every word of each talk.
+<!-- As part of our commitment to accessibility, we’re bringing real-time transcription (CART) to CSSconf EU. There will be a live feed of every word of each talk.
 
 We’re happy to be able to offer free, all-day childcare at the venue for children aged 3 and above. For parents with younger infants, we will provide a quiet room equipped with comfy seats, diapers and other essentials where you can retreat to throughout the day.
-Read more and register a free childcare ticket
+Read more and register a free childcare ticket -->
 
 ## Travel & Transport
 
@@ -91,27 +91,27 @@ Read more and register a free childcare ticket
 
 Berlin has two airports, both of which are located close to the city center, a 30-minute taxi ride from the venue (ca. EUR 30). There are also trains and buses that connect the airports to Berlin’s city center.
 
-Berlin-Tegel (TXL)
-Berlin-Schönefeld (SXF)
+* [Berlin-Tegel (TXL)](http://www.berlin-airport.de/en/travellers-txl/to-and-from/buses-and-trains/index.php)
+* [Berlin-Schönefeld (SXF)](http://www.berlin-airport.de/en/travellers-sxf/to-and-from/buses-and-trains/index.php)
 
 ### Public Transport
 
-Berlin has many public transport options. The subway, trains, buses, trams are all operated by BVG. We recommend getting one of the tourist tickets for the length of your stay – this will allow you to use all subway trains, trams and buses in all of Berlin, plus it comes with discounts for popular sights, museums, and other attractions.
+Berlin has many public transport options. The subway, trains, buses, trams are all operated by [BVG](http://www.bvg.de/en). We recommend getting one of the [tourist tickets](https://shop.bvg.de/index.php/group/73) for the length of your stay – this will allow you to use all subway trains, trams and buses in all of Berlin, plus it comes with discounts for popular sights, museums, and other attractions.
 
 ### Bike
 
-Berlin’s flat geography, its many bike lanes and the friendly weather in early May make it perfect to get around by bike! Check with your hotel or hostel if they have bikes to rent out, or find your perfect bike at one of the many bike rental places.
+Berlin’s flat geography, its many [bike lanes](https://en.wikipedia.org/wiki/Cycling_in_Berlin) and the [friendly weather in early June](http://www.yr.no/place/Germany/Berlin/Berlin/statistics.html) make it perfect to get around by bike! Check with your hotel or hostel if they have bikes to rent out, or find your perfect bike at one of the many [bike rental places](https://www.yelp.com/search?find_desc=bike+rental&find_loc=Berlin&start=0&cflt=bikerentals).
 
 ### Taxi
 
-Taxis in Berlin are affordable and everywhere. You can usually hail one on the street, or use apps like MyTaxi to order one.
+Taxis in Berlin are affordable and everywhere. You can usually hail one on the street, or use apps like [MyTaxi](https://de.mytaxi.com/en/index.html) to order one.
 
 ## Accommodation
 
-Below are a two hotels we recommend, both a short walk away from our venue. If neither of those fit your needs, check out HRS or private accommodation options like AirBnB or Couchsurfing.
+Below are a two hotels we recommend, both a short walk away from our venue. If neither of those fit your needs, check out [HRS](http://www.hrs.com/) or private accommodation options like AirBnB or Couchsurfing.
 
-* Hotel NHow (20 min walk)
-* Michelberger Hotel (20 min walk)
+* [Hotel NHow (20 min walk)](https://www.nhow-berlin.com/en/)
+* [Michelberger Hotel (20 min walk)](http://michelbergerhotel.com/en/)
 
 If you’d like to team up with other attendees to travel to or stay in Berlin, let us and the community know on Twitter: #cssconfeu – we will help spread the word!
 


### PR DESCRIPTION
Closes https://github.com/cssconf/2018.cssconf.eu/issues/80 

@Kriesse To check: 
- [x] is the `/diversity-support-ticket` page up to date? (since we would be linking there)
- [x] I added some changed copy where it was outdated but I'm not sure about my writing abilities right now 😅 Probably needs some smoothing 
- [x] all info up to date? I hid even more (Festival area details etc.)