### PR TITLE
Fix info link in About section on home page

### DIFF
--- a/contents/copy/home/cfs.md
+++ b/contents/copy/home/cfs.md
@@ -1,3 +1,3 @@
 <h2 class="fz--delta">About</h2>
 
-CSSconf EU 2018 is coming back to Berlin! <a href="/information" class="nowrap">Get all the infos and details</a>
+CSSconf EU 2018 is coming back to Berlin! <a href="/info" class="nowrap">Get all the infos and details</a>


### PR DESCRIPTION
Hi! Just one small fix for the home page:

**Before**

![screen shot 2018-02-16 at 14 02 58](https://user-images.githubusercontent.com/352105/36308879-b479fcce-1322-11e8-9983-6b1b84c991a0.png)

https://2018.cssconf.eu/information (leads to a 404)

**After**

![screen shot 2018-02-16 at 14 01 55](https://user-images.githubusercontent.com/352105/36308894-c4887dfc-1322-11e8-8a02-c909722f9f2c.png)

https://2018.cssconf.eu/info