### PR TITLE
Add styling for speaker details pages

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "locals": {
     "url": "https://2018.cssconf.eu",
+    "twitterHandle": "@CSSconfeu",
     "email": "contact@cssconf.eu",
     "name": "CSSconf EU | Friday, June 1 2018 | Berlin, Germany",
     "owner": "CSSconf EU Team",

--- a/contents/css/_components.speaker-links.css
+++ b/contents/css/_components.speaker-links.css
@@ -1,0 +1,8 @@
+.c-speaker-links {
+  font-size: 2.125rem;
+  margin-top: 1.5rem;
+
+  @media(--l) {
+    margin-top: 3.625rem;
+  }
+}

--- a/contents/css/_components.speaker-portrait.css
+++ b/contents/css/_components.speaker-portrait.css
@@ -34,10 +34,12 @@
     border: 1rem solid var(--color);
     border-right-width: 2rem;
     border-left-width: 2rem;
+    z-index: 1;
   }
 
   &__image {
     display: block;
+    filter: grayscale(100%);
     height: 100%;
     width: 100%;
   }

--- a/contents/css/_components.speaker-portrait.css
+++ b/contents/css/_components.speaker-portrait.css
@@ -1,0 +1,44 @@
+.c-speaker-portrait {
+  --border-size: 3px;
+
+  position: relative;
+  border: var(--border-size) solid var(--c-black);
+  background-color: var(--color);
+  width: 100%;
+  height: 100%;
+
+  &--variant-a {
+    --color: var(--c-blue-violet);
+  }
+
+  &--variant-b {
+    --color: var(--c-puerto-rico);
+  }
+
+  &--variant-c {
+    --color: var(--c-cinnabar);
+  }
+
+  &--variant-d {
+    --color: var(--c-illusion);
+  }
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    display: block;
+    border: 1rem solid var(--color);
+    border-right-width: 2rem;
+    border-left-width: 2rem;
+  }
+
+  &__image {
+    display: block;
+    height: 100%;
+    width: 100%;
+  }
+}

--- a/contents/css/_components.speaker.css
+++ b/contents/css/_components.speaker.css
@@ -1,0 +1,83 @@
+.c-speaker {
+  --background-top: 2rem;
+  --height: 20.5rem;
+  --margin-bottom: 2rem;
+  --margin-top: 2rem;
+
+  height: calc(var(--height) + var(--background-top));
+  margin-bottom: var(--margin-bottom);
+  margin-top: var(--margin-top);
+  position: relative;
+
+  @media(--m) {
+    --height: 28rem;
+    --margin-bottom: 3rem;
+    --margin-top: 6rem;
+  }
+
+  &::before {
+    background-color: var(--bg-color);
+    content: "";
+    height: var(--height);
+    position: absolute;
+    top: var(--background-top);
+    width: 100%;
+
+    @media screen and (min-width: 66.25rem) {
+      margin-left: -33.125rem;
+      left: 50%;
+      width: 66.25rem;
+    }
+  }
+
+  &--variant-a::before {
+    --bg-color: var(--c-cinnabar);
+  }
+
+  &--variant-b::before {
+    --bg-color: var(--c-blue-violet);
+  }
+
+  &--variant-c::before {
+    --bg-color: var(--c-illusion);
+  }
+
+  &--variant-d::before {
+    --bg-color: var(--c-martinique);
+  }
+}
+
+.c-speaker__image {
+  --image-size: 17.25rem;
+
+  height: var(--image-size);
+  margin: 0 auto;
+  width: var(--image-size);
+
+  @media(--m) {
+    --image-size: 22.5rem;
+  }
+}
+
+.c-speaker__container {
+  height: 100%;
+  position: relative;
+}
+
+.c-speaker__name {
+  --bottom: 2rem;
+  --left: 2rem;
+
+  bottom: var(--bottom);
+  color: var(--c-bright-sun);
+  left: var(--left);
+  margin-bottom: 0;
+  position: absolute;
+  word-spacing: 100rem; /* make the name break into multiple lines */
+  z-index: 1;
+
+  @media(--l) {
+    --bottom: 3rem;
+    --left: 5.5rem;
+  }
+}

--- a/contents/css/main.css
+++ b/contents/css/main.css
@@ -26,6 +26,9 @@
 @import "_components.nav-pages.css";
 @import "_components.nav-social.css";
 @import "_components.markdown.css";
+@import "_components.speaker.css";
+@import "_components.speaker-links.css";
+@import "_components.speaker-portrait.css";
 @import "_components.stage.css";
 @import "_components.paragraph-indent.css";
 /* Utilities */

--- a/templates/_macros.njk
+++ b/templates/_macros.njk
@@ -13,3 +13,11 @@
     <a class="c-nav-main__link" href="{{ link }}" {{ "target=\"_blank\"" if external }}>{{ label }}</a>
   </li>
 {% endmacro %}
+
+{% macro speakerPortrait(speaker, speakerImage) %}
+  <div class="c-speaker-portrait c-speaker-portrait--variant-{{ speaker.variant }}">
+    <img class="c-speaker-portrait__image"
+         src="{{ speakerImage }}"
+         alt="Photo of {{ speaker.name }}">
+  </div>
+{% endmacro %}

--- a/templates/layouts/default.html.njk
+++ b/templates/layouts/default.html.njk
@@ -6,10 +6,6 @@
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>{% if page.title %}{{ page.title }}{% endif %}</title>
-  {% if page.description %}
-    <meta name="description" content="{{ page.description }}">
-    <meta property="og:description" content="{{ page.description }}"/>
-  {% endif %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="{{ contents.css["main.css"].url }}">
   {#<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">#}
@@ -19,8 +15,21 @@
   <meta property="og:title"
         content="{{ page.title }}"/>
 
-  <meta property="og:image"
-        content="{{ url }}{{ contents.images['open-graph-image.jpg'].url }}"/>
+  {% block extraMetaData %}
+    {% set description = page.description or page.html | striptags | truncate(255) %}
+    {% set image = contents.images[page.metadata.image].url if page.metadata.image else contents.images['open-graph-image.jpg'].url %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="{{ twitterHandle }}">
+    <meta name="twitter:creator" content="{{ twitterHandle }}">
+    <meta name="twitter:title" content="{{ page.title }}">
+    <meta property="og:title" content="{{ page.title }}">
+    {% if description %}
+      <meta name="description" content="{{ description }}">
+      <meta name="twitter:description" content="{{ description }}">
+    {% endif %}
+    <meta name="twitter:image" content="{{ url }}{{ image }}">
+    <meta property="og:image" content="{{ url }}{{ image }}">
+  {% endblock %}
   {% include "../partials/favicon.html.njk" %}
 
   <script src="{{ contents.js['main.js'].url }}" defer></script>

--- a/templates/pages/speaker.html.njk
+++ b/templates/pages/speaker.html.njk
@@ -1,0 +1,61 @@
+{% extends "../layouts/default.html.njk" %}
+{% from "../_macros.njk" import speakerPortrait %}
+
+{% set speaker = page.metadata.speaker %}
+
+{% block content %}
+  <section class="c-speaker c-speaker--variant-{{ speaker.variant }}">
+    <div class="l-container c-speaker__container">
+      <figure class="c-speaker__image">
+        {{ speakerPortrait(speaker, contents.images.speaker[speaker.image.filename].url) }}
+      </figure>
+      <h1 class="c-speaker__name">{{ speaker.name }}</h1>
+    </div>
+  </section>
+
+  <div class="l-container">
+    <main>
+      {{ page.html }}
+
+      <ul class="c-speaker-links list pl0">
+        {% if speaker.links.twitter %}
+          <li>
+            <a href="{{ speaker.links.twitter }}">
+              {{ speaker.twitterHandle }}
+            </a>
+          </li>
+        {% endif %}
+        {% if speaker.links.github %}
+          <li>
+            <a href="{{ speaker.links.github }}">
+              {{ speaker.githubHandle }}
+            </a>
+          </li>
+        {% endif %}
+        {% if speaker.links.homepage %}
+          <li>
+            <a href="{{ speaker.links.homepage }}">
+              {{ speaker.links.homepage }}
+            </a>
+          </li>
+        {% endif %}
+      </ul>
+    </main>
+  </div>
+{% endblock %}
+
+{% block extraMetaData %}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="{{ twitterHandle }}">
+  {% if speaker.twitterHandle %}
+    <meta name="twitter:creator" content="{{ speaker.twitterHandle }}">
+  {% endif %}
+  <meta name="twitter:title" content="{{ speaker.talkTitle }}">
+  <meta property="og:title" content="{{ speaker.talkTitle }}">
+  <meta name="twitter:description" content="{{ speaker.firstname }} {{ speaker.lastname }} is speaking at JSConf EU 2018">
+  <meta name="description" content="{{ page.html | striptags | truncate(255) }}">
+  {% if speaker.image %}
+    <meta name="twitter:image" content="{{ url }}{{ contents.images.speaker[speaker.image.filename].url }}">
+    <meta property="og:image" content="{{ url }}{{ contents.images.speaker[speaker.image.filename].url }}" />
+  {% endif %}
+{% endblock %}

--- a/templates/pages/speaker.html.njk
+++ b/templates/pages/speaker.html.njk
@@ -25,20 +25,6 @@
             </a>
           </li>
         {% endif %}
-        {% if speaker.links.github %}
-          <li>
-            <a href="{{ speaker.links.github }}">
-              {{ speaker.githubHandle }}
-            </a>
-          </li>
-        {% endif %}
-        {% if speaker.links.homepage %}
-          <li>
-            <a href="{{ speaker.links.homepage }}">
-              {{ speaker.links.homepage }}
-            </a>
-          </li>
-        {% endif %}
       </ul>
     </main>
   </div>


### PR DESCRIPTION
This PR depends on functionality added in #99.

Fixes #74 (we still have to add styling for talk’s details part).