### PR TITLE
Improve readability of speaker names

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
   },
   "nunjucks": {
     "filterdir": "./templates/filters",
-    "filters": ["log", "sortObjects"]
+    "filters": ["log", "sortObjects", "splitString"]
   },
   "postcss": {
     "entrypoint": "css/main.css",

--- a/contents/css/_components.speaker-gallery.css
+++ b/contents/css/_components.speaker-gallery.css
@@ -39,18 +39,14 @@
     bottom: 0;
     color: var(--c-bright-sun);
     display: flex;
+    flex-direction: column;
     margin-bottom: 0;
     left: 0;
-    padding: 1rem;
+    padding: .5rem;
     position: absolute;
     right: 0;
     top: 0;
-    word-spacing: 100rem;
     z-index: 1;
-
-    &--variant-a,
-    &--variant-d {
-    }
 
     &--variant-b {
       transform: rotate(-90deg) translateY(100%);
@@ -58,7 +54,7 @@
     }
 
     &--variant-c {
-      align-items: flex-end;
+      justify-content: flex-end;
     }
 
     &--textcolor-white {
@@ -91,6 +87,37 @@
 
     &--textcolor-mint {
       color: var(--c-mint);
+    }
+  }
+
+  &__name-part {
+    span {
+      display: inline-block;
+      padding: 0 .5rem;
+    }
+
+    &:first-child,
+    &:last-child {
+      span {
+        padding-bottom: .25rem;
+        padding-top: .25rem;
+      }
+    }
+
+    &--variant-a span {
+      background-color: var(--c-cinnabar);
+    }
+
+    &--variant-b span {
+      background-color: var(--c-blue-violet);
+    }
+
+    &--variant-c span {
+      background-color: var(--c-illusion);
+    }
+
+    &--variant-d span {
+      background-color: var(--c-martinique);
     }
   }
 

--- a/templates/filters/splitString.js
+++ b/templates/filters/splitString.js
@@ -1,0 +1,6 @@
+module.exports = function(
+  str,
+  delimiter
+) {
+  return str.split(delimiter);
+};

--- a/templates/partials/speaker-gallery.html.njk
+++ b/templates/partials/speaker-gallery.html.njk
@@ -24,7 +24,13 @@
                        c-speaker-gallery__title--variant-{{ speaker.variant }}
                        c-speaker-gallery__title--textcolor-{{ speaker.textcolor }}
                        fz--epsilon">
-              {{ speaker.name }}
+              {% set speakerNameParts = speaker.name | splitString(' ') %}
+              {% for namePart in speakerNameParts %}
+                <div class="c-speaker-gallery__name-part
+                            c-speaker-gallery__name-part--variant-{{ speaker.variant }}">
+                  <span>{{ namePart }}</span>
+                </div>
+              {% endfor %}
             </h2>
           </a>
         </li>


### PR DESCRIPTION
This introduces background for speaker names in the gallery component
displayed on the homepage and the speakers page. We still have to play
around with `{{ speaker.textcolor }}` and backgrounds used per speaker.
