### PR TITLE
Add styling for schedule item's additional info

### DIFF
--- a/contents/css/_components.schedule-item.css
+++ b/contents/css/_components.schedule-item.css
@@ -2,9 +2,14 @@
   border-top: 2px solid var(--c-black);
   display: flex;
 
-  &__time {
+  &__time,
+  &__title {
     font-size: 1.5rem;
-    line-height: 3.2rem;
+    line-height: 1.25;
+    margin-top: .8rem;
+  }
+
+  &__time {
     width: 7.5rem;
   }
 
@@ -14,9 +19,7 @@
 
   &__title {
     color: var(--c-black);
-    font-size: 1.5rem;
-    line-height: 3.2rem;
-    margin: 0;
+    margin-bottom: .8rem;
   }
 
   &__misc {

--- a/contents/css/_components.schedule-item.css
+++ b/contents/css/_components.schedule-item.css
@@ -15,8 +15,9 @@
   &__title {
     color: var(--c-black);
     font-size: 1.5rem;
-    margin-bottom: .7rem;
-    margin-top: .7rem;
+    line-height: 3.2rem;
+    margin: 0;
+  }
 
   &__misc {
     background: var(--c-big-pink);

--- a/contents/css/_components.schedule-item.css
+++ b/contents/css/_components.schedule-item.css
@@ -17,6 +17,17 @@
     font-size: 1.5rem;
     margin-bottom: .7rem;
     margin-top: .7rem;
+
+  &__misc {
+    background: var(--c-big-pink);
+    padding: 1rem;
+
+    b {
+      color: var(--c-blue-violet);
+      display: inline-block;
+      margin-bottom: .5rem;
+      text-transform: uppercase;
+    }
   }
 }
 

--- a/templates/pages/schedule.html.njk
+++ b/templates/pages/schedule.html.njk
@@ -43,7 +43,9 @@
                     <h2 class="c-schedule-item__title">{{ data.title }}</h2>
                   {% endif %}
                   {% if data.misc %}
-                    {{ data.misc | nl2br }}
+                    <div class="c-schedule-item__misc">
+                      {{ data.misc | nl2br }}
+                    </div>
                   {% endif %}
                 </div>
               </div>


### PR DESCRIPTION
- added styling for schedule item’s additional info
- fixed a line height bug of schedule item’s title (now it’s aligned with the time)